### PR TITLE
Fix watch-server script on macOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "CC0-1.0",
   "scripts": {
     "build-server": "tslint --project . && tsc",
-    "watch-server": "cross-env NODE_ENV=development nodemon --watch src/**/* -e ts,tsx --exec ts-node src/server/server.ts"
+    "watch-server": "cross-env NODE_ENV=development nodemon --watch src/**/ -e ts,tsx --exec ts-node src/server/server.ts"
   },
   "devDependencies": {
     "@types/koa": "2.0.39",


### PR DESCRIPTION
The script
```
cross-env NODE_ENV=development nodemon --watch src/**/* -e ts,tsx --exec ts-node src/server/server.ts
```
is expanded to
```
cross-env NODE_ENV=development nodemon --watch src/server/config.ts src/server/config.ts src/server/logging.ts src/server/routes.ts src/server/server.ts -e ts,tsx --exec ts-node src/server/server.ts
```
 on macOS. Changing to `--watch src/**/` fixes the problem.